### PR TITLE
[TRUS-3796] - Resolve issue with ViewUtils.errorHref setting correct focus

### DIFF
--- a/app/views/ViewUtils.scala
+++ b/app/views/ViewUtils.scala
@@ -35,7 +35,7 @@ object ViewUtils {
       case x if x.contains("day") || x.contains("month") || x.contains("year") =>
         s"_${error.args.head}"
       case _ =>
-        val isSingleDateField = error.message.toLowerCase.contains("date")
+        val isSingleDateField = error.message.toLowerCase.contains("date") && !error.message.toLowerCase.contains("yesno")
         if (error.key.toLowerCase.contains("date") || isSingleDateField) {
           "_day"
         } else {

--- a/test/views/ViewUtilsSpec.scala
+++ b/test/views/ViewUtilsSpec.scala
@@ -22,7 +22,7 @@ class ViewUtilsSpec extends ViewSpecBase {
 
   "errorHref" must {
 
-    "refer to date field when error is for a single date input" in {
+    "refer to date field when error is for a single date input (lowercase message contains 'date' and not 'yesno')" in {
       val error = FormError(key = "value", message = "dateOfBirth.error.required")
       val result = ViewUtils.errorHref(error)
       result mustBe "value_day"
@@ -34,8 +34,14 @@ class ViewUtilsSpec extends ViewSpecBase {
       result mustBe "expiryDate_month"
     }
 
-    "not refer to date field when error is for a single input" in {
+    "not refer to date field when error is for a single input (lowercase message does not contains 'date')" in {
       val error = FormError(key = "value", message = "name.error.required")
+      val result = ViewUtils.errorHref(error)
+      result mustBe "value"
+    }
+
+    "not refer to date field when error is for a single input (lowercase message contains 'date' and 'yesno')" in {
+      val error = FormError(key = "value", message = "individualProtector.dateOfBirthYesNo.error.required")
       val result = ViewUtils.errorHref(error)
       result mustBe "value"
     }


### PR DESCRIPTION
Some message keys contain 'date' although they do not refer to date input fields,
for example 'individualProtector.dateOfBirthYesNo.error.required'
