### PR TITLE
DDCE-5067: Update to stop form submission with smart apostrophes

### DIFF
--- a/app/forms/InternationalAddressFormProvider.scala
+++ b/app/forms/InternationalAddressFormProvider.scala
@@ -22,7 +22,7 @@ import forms.mappings.Mappings
 import javax.inject.Inject
 import models.InternationalAddress
 import play.api.data.Forms._
-import play.api.data.{Form, Forms}
+import play.api.data.Form
 
 class InternationalAddressFormProvider @Inject() extends Mappings {
 
@@ -45,8 +45,7 @@ class InternationalAddressFormProvider @Inject() extends Mappings {
               regexp(Validation.addressLineRegex, "internationalAddress.error.line2.invalidCharacters")
             )),
       "line3" ->
-        optional(Forms.text
-          .transform(trimWhitespace, identity[String])
+        optional(text()
           .verifying(
             firstError(
               maxLength(35, "internationalAddress.error.line3.length"),

--- a/app/forms/UkAddressFormProvider.scala
+++ b/app/forms/UkAddressFormProvider.scala
@@ -22,7 +22,7 @@ import forms.mappings.Mappings
 import javax.inject.Inject
 import models.UkAddress
 import play.api.data.Forms._
-import play.api.data.{Form, Forms}
+import play.api.data.Form
 
 class UkAddressFormProvider @Inject() extends Mappings {
 
@@ -45,8 +45,7 @@ class UkAddressFormProvider @Inject() extends Mappings {
               regexp(Validation.addressLineRegex, "ukAddress.error.line2.invalidCharacters")
             )),
       "line3" ->
-        optional(Forms.text
-          .transform(trimWhitespace, identity[String])
+        optional(text()
           .verifying(
             firstError(
               maxLength(35, "ukAddress.error.line3.length"),
@@ -54,8 +53,7 @@ class UkAddressFormProvider @Inject() extends Mappings {
             ))
         ).transform(emptyToNone, identity[Option[String]]),
       "line4" ->
-        optional(Forms.text
-          .transform(trimWhitespace, identity[String])
+        optional(text()
           .verifying(
             firstError(
               maxLength(35, "ukAddress.error.line4.length"),

--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -76,7 +76,7 @@ trait Formatters {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] =
       data.get(key) match {
         case None | Some("") => Left(Seq(FormError(key, errorKey)))
-        case Some(s) => Right(s)
+        case Some(s)         => Right(s.trim.replace("‘", "'").replace("’", "'"))
       }
 
     override def unbind(key: String, value: String): Map[String, String] =

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,11 +23,8 @@ play.http.errorHandler = "handlers.ErrorHandler"
 # Play Modules
 # ~~~~
 # Additional play modules can be added here
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
 play.modules.enabled += "config.Module"
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,10 +5,10 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.21.0"
+  val bootstrapVersion = "7.23.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "7.19.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "7.29.0-play-28",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.13.0-play-28",
     "uk.gov.hmrc"       %% "domain"                        % "8.3.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % bootstrapVersion
@@ -16,12 +16,12 @@ object AppDependencies {
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"            %% "bootstrap-test-play-28"   % bootstrapVersion,
-    "org.scalatest"          %% "scalatest"                % "3.2.16",
+    "org.scalatest"          %% "scalatest"                % "3.2.17",
     "org.scalatestplus.play" %% "scalatestplus-play"       % "5.1.0",
     "org.scalatestplus"      %% "scalatestplus-scalacheck" % "3.1.0.0-RC2",
-    "org.jsoup"              %  "jsoup"                    % "1.16.1",
+    "org.jsoup"              %  "jsoup"                    % "1.17.2",
     "com.typesafe.play"      %% "play-test"                % PlayVersion.current,
-    "org.mockito"            %% "mockito-scala-scalatest"  % "1.17.22",
+    "org.mockito"            %% "mockito-scala-scalatest"  % "1.17.30",
     "org.scalacheck"         %% "scalacheck"               % "1.17.0",
     "com.github.tomakehurst" %  "wiremock-standalone"      % "2.27.2",
     "io.github.wolfendale"   %% "scalacheck-gen-regexp"    % "1.1.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.typesafeRepo("releases")
 // Try to remove when sbt 1.8.0+ and scoverage is 2.0.7+
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.20.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"  % "2.2.0")
 addSbtPlugin("com.typesafe.play"    % "sbt-plugin"          % "2.8.20")
 addSbtPlugin("com.beautiful-scala"  % "sbt-scalastyle"      % "1.5.1")

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -53,6 +53,11 @@ class MappingsSpec extends AnyWordSpec with Matchers with OptionValues with Mapp
       result.get mustEqual "foobar"
     }
 
+    "filter out smart apostrophes on binding" in {
+      val boundValue = testForm bind Map("value" -> "We’re ‘aving fish ‘n’ chips for tea")
+      boundValue.get mustEqual "We're 'aving fish 'n' chips for tea"
+    }
+
     "not bind an empty string" in {
       val result = testForm.bind(Map("value" -> ""))
       result.errors must contain(FormError("value", "error.required"))


### PR DESCRIPTION
Local Testing:

individual protector:
![Screenshot 2024-02-06 at 11 43 26](https://github.com/hmrc/register-trust-protector-frontend/assets/125281117/1bc810d4-9d63-451b-960c-f269bc94b25d)

![Screenshot 2024-02-06 at 11 44 06](https://github.com/hmrc/register-trust-protector-frontend/assets/125281117/5b59e534-7c83-4819-bb02-e767df76e269)

![Screenshot 2024-02-06 at 11 44 38](https://github.com/hmrc/register-trust-protector-frontend/assets/125281117/23b67777-1673-4d5c-9fe5-9befec5ff2d2)

business protector:

![Screenshot 2024-02-06 at 11 46 05](https://github.com/hmrc/register-trust-protector-frontend/assets/125281117/e9ceee7f-37f2-49a6-9c83-c3368a3fe123)

![Screenshot 2024-02-06 at 11 46 38](https://github.com/hmrc/register-trust-protector-frontend/assets/125281117/d4fac572-fc5b-4451-a9aa-69856fdae61d)

![Screenshot 2024-02-06 at 11 46 49](https://github.com/hmrc/register-trust-protector-frontend/assets/125281117/8b597e2b-87c1-4e69-a5ac-0f711ea18322)

